### PR TITLE
Add missing curl and coreutils in pulsarbot docker image

### DIFF
--- a/pulsarbot/Dockerfile
+++ b/pulsarbot/Dockerfile
@@ -9,7 +9,7 @@ LABEL "com.github.actions.description"="Pulsar Bot"
 LABEL "com.github.actions.icon"="git-commit"
 LABEL "com.github.actions.color"="gray-dark"
 
-RUN apk add --update git jq bash && rm -rf /var/cache/apk/*
+RUN apk add --update git jq bash curl coreutils && rm -rf /var/cache/apk/*
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
*Motivation*

`curl` and `base64` are required for running pulsarbot