### PR TITLE
Use GITHUB_SHA for finding pr base commit

### DIFF
--- a/diff-only/entrypoint.sh
+++ b/diff-only/entrypoint.sh
@@ -7,9 +7,8 @@ COMMITS=$(jq '.pull_request.commits' "${GITHUB_EVENT_PATH}")
 echo "COMMITS: ${COMMITS}"
 
 git --version
-git rev-parse --abbrev-ref HEAD
 
-CHANGED_DIRS=$(git diff --dirstat=files,0 HEAD~${COMMITS} | awk '{ print $2 }')
+CHANGED_DIRS=$(git diff --dirstat=files,0 ${GITHUB_SHA}~${COMMITS} | awk '{ print $2 }')
 echo "CHANGED_DIRS are : ${CHANGED_DIRS}"
 
 found_changed_dir_not_in_target_dirs="no"


### PR DESCRIPTION
Per documentation:

```
GITHUB_SHA is Last merge commit on the GITHUB_REF branch
GITHUB_REF is PR merge branch refs/pull/:prNumber/merge
```

Therefore, we could use GITHUB_SHA~commitNumber for pr base commit.