### PR TITLE
Detect when there are changes in the root directory

### DIFF
--- a/diff-only/entrypoint.sh
+++ b/diff-only/entrypoint.sh
@@ -9,7 +9,7 @@ echo "COMMITS: ${COMMITS}"
 git --version
 git rev-parse --abbrev-ref HEAD
 
-CHANGED_DIRS=$(git diff --dirstat=files,0 HEAD~${COMMITS} | awk '{ print $2 }')
+CHANGED_DIRS=$(git diff --name-only HEAD~${COMMITS} | awk -F "/*[^/]*/*$" '{ print ($1 == "" ? "." : $1); }' | sort | uniq)
 echo "CHANGED_DIRS are : ${CHANGED_DIRS}"
 
 found_changed_dir_not_in_target_dirs="no"


### PR DESCRIPTION
Fixes #10, https://github.com/apache/pulsar/issues/8362

The problem is that `git diff --dirstat=files,0 <commit>` doesn't
show changes in the root directory.
Replace with
`git diff --name-only <commit> | awk -F "/*[^/]*/*$" '{ print ($1 == "" ? "." : $1); }' | sort | uniq`
which will list changes in the root directory as "."