### PR TITLE
Set 'changed_only' to 'no' if commits cannot be found in diff-only action

### DIFF
--- a/diff-only/entrypoint.sh
+++ b/diff-only/entrypoint.sh
@@ -9,30 +9,36 @@ echo "COMMITS: ${COMMITS}"
 git --version
 git rev-parse --abbrev-ref HEAD
 
-CHANGED_DIRS=$(git diff --name-only HEAD~${COMMITS} | awk -F "/*[^/]*/*$" '{ print ($1 == "" ? "." : $1); }' | sort | uniq)
-echo "CHANGED_DIRS are : ${CHANGED_DIRS}"
+FIRST_COMMIT=$(git rev-parse HEAD~${COMMITS} 2> /dev/null)
+if [ $? -eq 0 ]; then
+    CHANGED_DIRS=$(git diff --name-only $FIRST_COMMIT | awk -F "/*[^/]*/*$" '{ print ($1 == "" ? "." : $1); }' | sort | uniq)
+    echo "CHANGED_DIRS are : ${CHANGED_DIRS}"
 
-found_changed_dir_not_in_target_dirs="no"
-for changed_dir in ${CHANGED_DIRS}
-do
-    matched="no"
-    for target_dir in "${TARGET_DIRS[@]}"
+    found_changed_dir_not_in_target_dirs="no"
+    for changed_dir in ${CHANGED_DIRS}
     do
-        if [[ ${changed_dir} == "${target_dir}"* ]]; then
-            matched="yes"
+        matched="no"
+        for target_dir in "${TARGET_DIRS[@]}"
+        do
+            if [[ ${changed_dir} == "${target_dir}"* ]]; then
+                matched="yes"
+                break
+            fi
+        done
+        if [[ ${matched} == "no" ]]; then
+            found_changed_dir_not_in_target_dirs="yes"
             break
         fi
     done
-    if [[ ${matched} == "no" ]]; then
-        found_changed_dir_not_in_target_dirs="yes"
-        break
-    fi
-done
 
-if [[ ${found_changed_dir_not_in_target_dirs} == "yes" ]]; then
-    echo "Changes ${CHANGED_DIRS} not only in $*, setting 'changed_only' to 'no'"
-    echo ::set-output name=changed_only::no
+    if [[ ${found_changed_dir_not_in_target_dirs} == "yes" ]]; then
+        echo "Changes ${CHANGED_DIRS} not only in $*, setting 'changed_only' to 'no'"
+        echo ::set-output name=changed_only::no
+    else
+        echo "Changes ${CHANGED_DIRS} only in $*, setting 'changed_only' to 'yes'"
+        echo ::set-output name=changed_only::yes
+    fi
 else
-    echo "Changes ${CHANGED_DIRS} only in $*, setting 'changed_only' to 'yes'"
-    echo ::set-output name=changed_only::yes
+    echo "Cannot find first commit. Setting 'changed_only' to 'no'."
+    echo ::set-output name=changed_only::no
 fi

--- a/diff-only/entrypoint.sh
+++ b/diff-only/entrypoint.sh
@@ -9,36 +9,41 @@ echo "COMMITS: ${COMMITS}"
 git --version
 git rev-parse --abbrev-ref HEAD
 
-FIRST_COMMIT=$(git rev-parse HEAD~${COMMITS} 2> /dev/null)
-if [ $? -eq 0 ]; then
-    CHANGED_DIRS=$(git diff --name-only $FIRST_COMMIT | awk -F "/*[^/]*/*$" '{ print ($1 == "" ? "." : $1); }' | sort | uniq)
-    echo "CHANGED_DIRS are : ${CHANGED_DIRS}"
+if [[ $COMMITS -gt 0 ]]; then
+    FIRST_COMMIT=$(git rev-parse HEAD~${COMMITS} 2> /dev/null)
+    if [ $? -eq 0 ]; then
+        CHANGED_DIRS=$(git diff --name-only $FIRST_COMMIT | awk -F "/*[^/]*/*$" '{ print ($1 == "" ? "." : $1); }' | sort | uniq)
+        echo "CHANGED_DIRS are : ${CHANGED_DIRS}"
 
-    found_changed_dir_not_in_target_dirs="no"
-    for changed_dir in ${CHANGED_DIRS}
-    do
-        matched="no"
-        for target_dir in "${TARGET_DIRS[@]}"
+        found_changed_dir_not_in_target_dirs="no"
+        for changed_dir in ${CHANGED_DIRS}
         do
-            if [[ ${changed_dir} == "${target_dir}"* ]]; then
-                matched="yes"
+            matched="no"
+            for target_dir in "${TARGET_DIRS[@]}"
+            do
+                if [[ ${changed_dir} == "${target_dir}"* ]]; then
+                    matched="yes"
+                    break
+                fi
+            done
+            if [[ ${matched} == "no" ]]; then
+                found_changed_dir_not_in_target_dirs="yes"
                 break
             fi
         done
-        if [[ ${matched} == "no" ]]; then
-            found_changed_dir_not_in_target_dirs="yes"
-            break
-        fi
-    done
 
-    if [[ ${found_changed_dir_not_in_target_dirs} == "yes" ]]; then
-        echo "Changes ${CHANGED_DIRS} not only in $*, setting 'changed_only' to 'no'"
-        echo ::set-output name=changed_only::no
+        if [[ ${found_changed_dir_not_in_target_dirs} == "yes" ]]; then
+            echo "Changes ${CHANGED_DIRS} not only in $*, setting 'changed_only' to 'no'"
+            echo ::set-output name=changed_only::no
+        else
+            echo "Changes ${CHANGED_DIRS} only in $*, setting 'changed_only' to 'yes'"
+            echo ::set-output name=changed_only::yes
+        fi
     else
-        echo "Changes ${CHANGED_DIRS} only in $*, setting 'changed_only' to 'yes'"
-        echo ::set-output name=changed_only::yes
+        echo "Cannot find first commit. Setting 'changed_only' to 'no'."
+        echo ::set-output name=changed_only::no
     fi
 else
-    echo "Cannot find first commit. Setting 'changed_only' to 'no'."
+    echo "Cannot find number of commits in pull_request. Setting 'changed_only' to 'no'."
     echo ::set-output name=changed_only::no
 fi


### PR DESCRIPTION
Fixes #12 https://github.com/apache/pulsar/issues/9526

The current solution causes the build to skip tests in Pulsar builds when the pull request commits cannot be found. It's better that diff-only script sets 'changed_only' to 'no' when it's not able to determine the correct result.

The commit for a PR won't be found when shallow clones are used and there are more commits in the PR than the depth of the shallow clone. The Pulsar GitHub Action workflows use shallow clone with the depth of 25 commits. This PR will support such PRs by defaulting to `changed_only` to `no` when the commit cannot be found.

This PR also fixes support for non-PR events such as `push` event. `changed_only` is set to `no` when the triggering event isn't a `pull_request` event.