### PR TITLE
[pulsarbot] Use gawk (gnu awk) so that CSV can be properly handled

### DIFF
--- a/pulsarbot/Dockerfile
+++ b/pulsarbot/Dockerfile
@@ -9,7 +9,7 @@ LABEL "com.github.actions.description"="Pulsar Bot"
 LABEL "com.github.actions.icon"="git-commit"
 LABEL "com.github.actions.color"="gray-dark"
 
-RUN apk add --update git jq bash curl coreutils && rm -rf /var/cache/apk/*
+RUN apk add --update git jq bash curl coreutils gawk && rm -rf /var/cache/apk/*
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/pulsarbot/entrypoint.sh
+++ b/pulsarbot/entrypoint.sh
@@ -67,7 +67,16 @@ function get_runs() {
 
 # take the last attempt for each workflow to prevent restarting old runs
 function filter_oldruns() {
-    awk -F, '{ if (NR > 1 && LAST != null && LAST != $1) {print LASTLINE; print $0; LAST=null; LASTLINE=null} else { LAST = $1;LASTLINE = $0} } END { if (LASTLINE != null) { print LASTLINE } }'
+    awk '
+    BEGIN { FPAT="([^,]+)|(\"[^\"]+\")" }
+    { 
+        if (NR > 1 && LAST != null && LAST != $1) {
+            print LASTLINE; print $0; LAST=null; LASTLINE=null
+        } else {
+            LAST = $1;LASTLINE = $0
+        }
+    } 
+    END { if (LASTLINE != null) { print LASTLINE } }'
 }
 
 function get_all_runs() {
@@ -91,7 +100,12 @@ function get_all_runs() {
 # return url and name for failed or cancelled jobs that are the most recent ones for each workflow
 function find_failed_or_cancelled() {
     get_all_runs | filter_oldruns \
-      | awk -F, '{ gsub(/"/, ""); if ($3 == "failure" || $3 == "cancelled") { print $4 "\t" $5 "\t" $6 } }'
+      | awk '
+      BEGIN { FPAT="([^,]+)|(\"[^\"]+\")" } 
+      { 
+        gsub(/"/, "", $3); gsub(/"/, "", $4); gsub(/"/, "", $5); gsub(/"/, "", $6); 
+        if ($3 == "failure" || $3 == "cancelled") { print $4 "\t" $5 "\t" $6 }
+      }'
 }
 
 # allocate file descriptor for the failed or cancelled url and name listing


### PR DESCRIPTION
### Motivation

- previously a comma in the name caused a parsing issue
  example issue: https://github.com/apache/pulsar/runs/6130584084?check_suite_focus=true#step:5:11
  fails to parse `CI - CPP, Python Tests`

### Modifications
- install gnu awk (gawk) in Dockerfile
- use gawk's FPAT feature to parse double quoted CSV
  -  removing double quotes must be done separately for each field. `gsub(/"/, "")` doesn't work anymore to remove all double quotes.