### PR TITLE
[pulsarbot] trim whitespaces in comments

### DIFF
--- a/pulsarbot/entrypoint.sh
+++ b/pulsarbot/entrypoint.sh
@@ -6,6 +6,7 @@ fi
 set -e
 
 COMMENT_BODY=$(jq -r '.comment.body' "${GITHUB_EVENT_PATH}")
+COMMENT_BODY=$(echo "$COMMENT_BODY" | xargs)
 
 BOT_COMMAND_PREFIX="/pulsarbot"
 BOT_TARGET_REPOSITORY=${GITHUB_REPOSITORY:-"apache/pulsar"}


### PR DESCRIPTION
Contributors' comments often contains whitespaces and such whitespaces should not affect command validation.

See also https://github.com/apache/pulsar/runs/7245841750?check_suite_focus=true for a bad case.

cc @lhotari 