### PR TITLE
avoid duplicate docbot comment

### DIFF
--- a/docbot/main.go
+++ b/docbot/main.go
@@ -309,13 +309,13 @@ func (a *Action) onPullRequestOpenedOrEdited() error {
 		}
 	}
 
-	if _, exist := currentLabelsSet[a.config.GetLabelMissing()]; exist && checkedCount == 0 {
-		logger.Infoln("Already added missing label.")
-		return fmt.Errorf("%s", MessageLabelMissing)
-	}
-
 	// Add missing label
 	if a.config.GetEnableLabelMissing() && checkedCount == 0 {
+		if _, exist := currentLabelsSet[a.config.GetLabelMissing()]; exist {
+			logger.Infoln("Already added missing label.")
+			return fmt.Errorf("%s", MessageLabelMissing)
+		}
+
 		logger.Infoln("@Add missing label")
 		_, _, err = a.client.Issues.AddLabelsToIssue(a.globalContext,
 			a.config.GetOwner(), a.config.GetRepo(), a.config.GetNumber(),
@@ -423,13 +423,13 @@ func (a *Action) onPullRequestLabeledOrUnlabeled() error {
 		}
 	}
 
-	if _, exist := currentLabelsSet[a.config.GetLabelMissing()]; exist && checkedCount == 0 {
-		logger.Infoln("Already added missing label.")
-		return fmt.Errorf("%s", MessageLabelMissing)
-	}
-
 	// Add missing label
 	if a.config.GetEnableLabelMissing() && checkedCount == 0 {
+		if _, exist := currentLabelsSet[a.config.GetLabelMissing()]; exist {
+			logger.Infoln("Already added missing label.")
+			return fmt.Errorf("%s", MessageLabelMissing)
+		}
+
 		logger.Infoln("@Add missing label")
 		_, _, err = a.client.Issues.AddLabelsToIssue(a.globalContext,
 			a.config.GetOwner(), a.config.GetRepo(), a.config.GetNumber(),

--- a/docbot/main.go
+++ b/docbot/main.go
@@ -309,6 +309,11 @@ func (a *Action) onPullRequestOpenedOrEdited() error {
 		}
 	}
 
+	if _, exist := currentLabelsSet[a.config.GetLabelMissing()]; exist && checkedCount == 0 {
+		logger.Infoln("Already added missing label.")
+		return fmt.Errorf("%s", MessageLabelMissing)
+	}
+
 	// Add missing label
 	if a.config.GetEnableLabelMissing() && checkedCount == 0 {
 		logger.Infoln("@Add missing label")
@@ -416,6 +421,11 @@ func (a *Action) onPullRequestLabeledOrUnlabeled() error {
 		if err != nil {
 			return fmt.Errorf("remove label %v: %v", label, err)
 		}
+	}
+
+	if _, exist := currentLabelsSet[a.config.GetLabelMissing()]; exist && checkedCount == 0 {
+		logger.Infoln("Already added missing label.")
+		return fmt.Errorf("%s", MessageLabelMissing)
 	}
 
 	// Add missing label


### PR DESCRIPTION
We should send the comment only once when we add `doc/label-missing` label once.

Otherwise, it may produce duplicate comments which act as spam. For example, https://github.com/apache/pulsar/pull/17009#issuecomment-1213636320.

cc @michaeljmarshall @maxsxu @nodece 