### PR TITLE
Fix remove labels

### DIFF
--- a/docbot/action.go
+++ b/docbot/action.go
@@ -135,15 +135,10 @@ func (a *Action) checkLabels() error {
 		}
 
 		for label, checked := range expectedLabelsMap {
-			_, found := prLabels[label]
-			if found {
-				if !checked {
-					labelsToRemove[label] = struct{}{}
-				}
-			} else {
-				if checked {
-					labelsToAdd[label] = struct{}{}
-				}
+			if _, found := prLabels[label]; found && !checked {
+				labelsToRemove[label] = struct{}{}
+			} else if !found && checked {
+				labelsToAdd[label] = struct{}{}
 			}
 		}
 	}


### PR DESCRIPTION
### Motivation

If different labels are selected multiple times, the previously selected labels cannot be deleted correctly.

Tests have been added and tested in my repo, see the following log:

```
[INFO] 2022/09/08 09:09:44 @Start docbot
[INFO] 2022/09/08 09:09:44 @EventName is PR
[INFO] 2022/09/08 09:09:44 PR description: Signed-off-by: Zixuan Liu <nodeces@gmail.com>

test


- [ ] `doc-not-needed`
- [x] `doc` 

[INFO] 2022/09/08 09:09:44 @List repo labels
[INFO] 2022/09/08 09:09:44 Repo labels: map[bug:{} doc:{} doc-complete:{} doc-label-missing:{} doc-not-needed:{} doc-required:{} documentation:{} duplicate:{} enhancement:{} good first issue:{} help wanted:{} invalid:{} question:{} wontfix:{}]
[INFO] 2022/09/08 09:09:44 PR labels: map[doc-not-needed:{} duplicate:{} enhancement:{}]
[INFO] 2022/09/08 09:09:44 Expected labels: map[doc:true doc-not-needed:false]
[INFO] 2022/09/08 09:09:44 Labels to add: [doc]
[INFO] 2022/09/08 09:09:45 Labels to remove: [doc-not-needed]
```

/cc @maxsxu @tisonkun @Anonymitaet 