### PR TITLE
[fix][paths-filter] Upgrade GitHub Actions runtime to node16 to fix deprecation warning

### DIFF
--- a/paths-filter/action.yml
+++ b/paths-filter/action.yml
@@ -43,7 +43,7 @@ outputs:
   changes:
     description: JSON array with names of all filters matching any of changed files
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'
 branding:
   color: blue


### PR DESCRIPTION
- Node.js 12 actions are deprecated. For more information, see:
  https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/