### PR TITLE
[fix][ci] Remove deprecated usage of ::set-output

### DIFF
--- a/diff-only/entrypoint.sh
+++ b/diff-only/entrypoint.sh
@@ -34,16 +34,17 @@ if [[ $COMMITS -gt 0 ]]; then
 
         if [[ ${found_changed_dir_not_in_target_dirs} == "yes" ]]; then
             echo "Changes ${CHANGED_DIRS} not only in $*, setting 'changed_only' to 'no'"
-            echo ::set-output name=changed_only::no
+            echo "changed_only=no" >> $GITHUB_OUTPUT
         else
             echo "Changes ${CHANGED_DIRS} only in $*, setting 'changed_only' to 'yes'"
-            echo ::set-output name=changed_only::yes
+            echo "changed_only=yes" >> $GITHUB_OUTPUT
         fi
     else
         echo "Cannot find first commit. Setting 'changed_only' to 'no'."
-        echo ::set-output name=changed_only::no
+        echo "changed_only=no" >> $GITHUB_OUTPUT
     fi
 else
     echo "Cannot find number of commits in pull_request. Setting 'changed_only' to 'no'."
-    echo ::set-output name=changed_only::no
+    echo "changed_only=no" >> $GITHUB_OUTPUT
+
 fi


### PR DESCRIPTION
### Motivation

Usage of `::set-output` in GH actions is deprecated and it will removed soon.
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

### Modifications

* Replaced ::set-output with appending output to $GITHUB_OUTPUT env as mentioned here https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter
