### PR TITLE
[improve][ci] support to add first contribution label

### DIFF
--- a/docbot/action.go
+++ b/docbot/action.go
@@ -44,7 +44,6 @@ type Action struct {
 	client        *github.Client
 
 	prNumber int
-	actor    string
 }
 
 func NewAction(ac *ActionConfig) *Action {
@@ -157,8 +156,8 @@ func (a *Action) checkLabels() error {
 		}
 	}
 
-	logger.Infoln("Check first contribution.")
-	if _, ok := labelsToAdd[firstContributionLabel]; a.isFirstPR() && !ok {
+	logger.Infoln("Check first contribution: " + *pr.GetUser().Login)
+	if _, ok := labelsToAdd[firstContributionLabel]; a.isFirstPR(*pr.GetUser().Login) && !ok {
 		logger.Infoln("Is first contribution.")
 		labelsToAdd[firstContributionLabel] = struct{}{}
 	}
@@ -356,11 +355,11 @@ func (a *Action) getLabelMissingMessage() string {
 	return msg
 }
 
-func (a *Action) isFirstPR() bool {
+func (a *Action) isFirstPR(login string) bool {
 	jsonData := map[string]string{
 		"query": `
             {
-			  user(login: "` + a.actor + `") {
+			  user(login: "` + login + `") {
 				contributionsCollection {
 				  commitContributionsByRepository(maxRepositories: 100) {
 					contributions {
@@ -393,5 +392,5 @@ func (a *Action) isFirstPR() bool {
 	data, _ := io.ReadAll(response.Body)
 	// just search string
 	expected := `"repository":{"owner":{"login":"apache"},"name":"pulsar"}`
-	return strings.Contains(string(data), expected)
+	return !strings.Contains(string(data), expected)
 }

--- a/docbot/action.go
+++ b/docbot/action.go
@@ -157,6 +157,12 @@ func (a *Action) checkLabels() error {
 		}
 	}
 
+	logger.Infoln("Check first contribution.")
+	if _, ok := labelsToAdd[firstContributionLabel]; a.isFirstPR() && !ok {
+		logger.Infoln("Is first contribution.")
+		labelsToAdd[firstContributionLabel] = struct{}{}
+	}
+
 	if len(labelsToAdd) == 0 {
 		logger.Infoln("No labels to add.")
 	} else {
@@ -181,10 +187,6 @@ func (a *Action) checkLabels() error {
 				return err
 			}
 		}
-	}
-
-	if _, ok := labelsToAdd[firstContributionLabel]; a.isFirstPR() && !ok {
-		labelsToAdd[firstContributionLabel] = struct{}{}
 	}
 
 	if checkedCount == 0 {

--- a/docbot/action.yml
+++ b/docbot/action.yml
@@ -11,7 +11,7 @@ runs:
     - name: Checkout
       uses: actions/checkout@v3
       with:
-        repository: apache/pulsar-test-infra
+        repository: labuladong/pulsar-test-infra
     - name: Setup Go
       uses: actions/setup-go@v3
       with:

--- a/docbot/main.go
+++ b/docbot/main.go
@@ -19,7 +19,6 @@ func main() {
 	if err != nil {
 		logger.Fatalf("Get github context: %v\n", err)
 	}
-	action.actor = githubContext.Actor
 
 	switch githubContext.EventName {
 	case "pull_request", "pull_request_target":

--- a/docbot/main.go
+++ b/docbot/main.go
@@ -19,6 +19,7 @@ func main() {
 	if err != nil {
 		logger.Fatalf("Get github context: %v\n", err)
 	}
+	action.actor = githubContext.Actor
 
 	switch githubContext.EventName {
 	case "pull_request", "pull_request_target":


### PR DESCRIPTION
Use GitHub graphQL API to check `first contribution`.

The example graphQL output is:

```json
{"data":{"user":{"contributionsCollection":{"commitContributionsByRepository":[{"contributions":{"totalCount":15},"repository":{"owner":{"login":"apache"},"name":"pulsar"}},{"login":"apache"},"name":"pulsar-client-go"}},{"contributions":{"totalCount":1},"repository":{"owner":{"login":"labuladong"},"name":"pulsar-note"}},{"contributions":{"totalCount":1},"repository":{"owner":{"login":"apache"},"name":"pulsar-site"}}]}}}}
```

So just search the string to check if the PR is the first contribution.

First pull request will be added a `first-pr` label, example here: https://github.com/labuladong/pulsar/pull/11

Not first pull request will do nothing, example here: https://github.com/labuladong/pulsar/pull/12

This part is just for testing, I will remove it before merging:

```java
- name: Checkout
      uses: actions/checkout@v3
      with:
        repository: labuladong/pulsar-test-infra
```
